### PR TITLE
Remove duplicate `curl` from install command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Requirements:
 
 On Debian/Ubuntu Linx systems you can install all of them using command:
 ```
-sudo apt install jq curl curl 
+sudo apt install jq curl 
 ```
 Or similar way in other Linux systems.
 


### PR DESCRIPTION
Just researching running my own self hosted element server and found your wonderful project. Noticed a small typo so figured I would just open a quick PR to help clean up. Great work - thanks for open sourcing.